### PR TITLE
Calculate the bucketURL and grant client access to it.

### DIFF
--- a/lib/easy_cfs_images.js
+++ b/lib/easy_cfs_images.js
@@ -25,7 +25,7 @@ var factory = new ImageCollectionFactory(
   myBucketName,
   {
     publicRead: true,
-    bucketUrl: 'https://your-bucket.s3.amazonaws.com/' // URL for your specific bucket
+    bucketRegion: eu-west-1 // optional, leave blank for default region
   }
 );
 
@@ -38,7 +38,11 @@ ImageCollectionFactory = function (accessKeyId, secretAccessKey, bucketName, opt
   //Set Cache Control headers so we don't overload our meteor server with http requests
   FS.HTTP.setHeadersForGet([['Cache-Control', 'public, max-age=31536000']]);
 
-  var bucketUrl = options && options.bucketUrl;
+  var region = (options && options.bucketRegion) || "";
+  if (region) {
+    region = "-"+region;
+  }
+  factory.bucketUrl = "https://"+bucketName+region+".s3.amazonaws.com/";
   var publicRead = options && options.publicRead;
   var acl = publicRead ? 'public-read' : 'private';
 
@@ -113,7 +117,7 @@ ImageCollectionFactory = function (accessKeyId, secretAccessKey, bucketName, opt
     return collection;
   };
 
-  if (publicRead && bucketUrl) {
+  if (publicRead && factory.bucketUrl) {
     // Save the old url method
     FS.File.prototype._url = FS.File.prototype.url;
 
@@ -128,10 +132,29 @@ ImageCollectionFactory = function (accessKeyId, secretAccessKey, bucketName, opt
       // TODO: figure out a less hacky way. Use hasStored()?
       if (self._url(options)) {
         var fileKey = store + '/' + self.collectionName + '/' + self._id + '-' + self.name();
-        return bucketUrl + fileKey;
+        return factory.bucketUrl + fileKey;
       }
       return null;
     }
   }
 
 };
+
+EasyImages = (function() {
+
+  function required(options, name) {
+    if (options[name]) {
+      return options[name];
+    }
+    throw new Meteor.Error("Missing required parameter '"+name+"' for EasyImages configuration");
+  }
+
+  return {
+    configure: function(options) {
+      this.imageCollectionFactory = required(options, 'imageCollectionFactory');
+    },
+    bucketUrl: function() {
+      return this.imageCollectionFactory.bucketUrl;
+    }
+  };
+})();

--- a/package.js
+++ b/package.js
@@ -18,6 +18,7 @@ Package.onUse(function (api) {
     'templating'
   ]);
   api.addFiles('lib/easy_cfs_images.js', ['server', 'client']);
+  api.addFiles('server/methods.js', 'server');
   api.addFiles(
     [
       'client/views/display-image.html',
@@ -27,4 +28,5 @@ Package.onUse(function (api) {
     ],
     'client');
   api.export('ImageCollectionFactory');
+  api.export('EasyImages');
 });

--- a/server/methods.js
+++ b/server/methods.js
@@ -1,0 +1,5 @@
+Meteor.methods({
+  bucketUrl: function() {
+    return EasyImages.bucketUrl();
+  }
+});


### PR DESCRIPTION
This required some refactoring to centralize configuration of
EasyImages. Setup now includes this step:

EasyImages.configure({imageCollectionFactory: imageCollectionFactory});

Bucket URL can then be retrieved with:

``` javascript
var bucketUrl;
Meteor.call('bucketUrl', function(error, response) { bucketURL =
response });
```
